### PR TITLE
Feature/save and view covers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,19 +12,16 @@ var coverImage = document.querySelector(".cover-image");
 var coverTitle = document.querySelector(".cover-title");
 var coverTagLine1 = document.querySelector(".tagline-1");
 var coverTagLine2 = document.querySelector(".tagline-2");
-
 var showRandomButton = document.querySelector(".random-cover-button");
 var homeButton = document.querySelector(".home-button");
 var makeYourCoverButton = document.querySelector(".make-new-button");
 var viewCoversButton = document.querySelector(".view-saved-button");
 var saveCoverButton = document.querySelector(".save-cover-button");
 var myBookButton = document.querySelector(".create-new-book-button");
-
 var userCoverInput = document.querySelector(".user-cover");
 var userTitleInput = document.querySelector(".user-title");
 var userDescriptionInput1 = document.querySelector(".user-desc1");
 var userDescriptionInput2 = document.querySelector(".user-desc2");
-
 var formView = document.querySelector(".form-view");
 var homeView = document.querySelector(".home-view");
 var savedCoversView = document.querySelector(".saved-view");
@@ -40,8 +37,6 @@ myBookButton.addEventListener("click", displayUserCover);
 saveCoverButton.addEventListener("click", saveCovers)
 
 // Create your event handlers and other functions here 👇
-
-
 
 // We've provided one function to get you started
 function getRandomIndex(array) {

--- a/src/main.js
+++ b/src/main.js
@@ -48,7 +48,6 @@ function getRandomIndex(array) {
 }
 
 function displayCover(bookCoverObj) {
-  console.log(currentCover)
   coverImage.src = bookCoverObj.cover;
   coverTitle.innerText = bookCoverObj.title;
   coverTagLine1.innerText = bookCoverObj.tagline1;
@@ -128,11 +127,11 @@ function getUserInput() {
   )
   return userBookCover;
   displayCover(userBookCover);
-
-
 }
 
 function saveCovers() {
-  savedCovers.push(currentCover)
-  console.log(savedCovers);
-}
+    if (!savedCovers.includes(currentCover)) {
+      savedCovers.push(currentCover)
+    }
+    console.log(savedCovers);
+  }

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@
 var savedCovers = [
   new Cover("http://3.bp.blogspot.com/-iE4p9grvfpQ/VSfZT0vH2UI/AAAAAAAANq8/wwQZssi-V5g/s1600/Do%2BNot%2BForsake%2BMe%2B-%2BImage.jpg", "Sunsets and Sorrows", "sunsets", "sorrows")
 ];
+
 var currentCover = randomizeBookCover();
 
 var coverImage = document.querySelector(".cover-image");
@@ -29,14 +30,17 @@ var homeView = document.querySelector(".home-view");
 var savedCoversView = document.querySelector(".saved-view");
 
 // Add your event listeners here 👇
-window.onLoad = displayCover(currentCover)
+window.onLoad = displayRandomOnLoad();
 showRandomButton.addEventListener("click", displayRandomButton);
 makeYourCoverButton.addEventListener("click", displayViewForm);
 homeButton.addEventListener("click", displayHomeView);
 viewCoversButton.addEventListener("click", displaySavedCovers);
 myBookButton.addEventListener("click", displayUserCover);
+saveCoverButton.addEventListener("click", saveCovers)
 
 // Create your event handlers and other functions here 👇
+
+
 
 // We've provided one function to get you started
 function getRandomIndex(array) {
@@ -44,10 +48,12 @@ function getRandomIndex(array) {
 }
 
 function displayCover(bookCoverObj) {
+  console.log(currentCover)
   coverImage.src = bookCoverObj.cover;
   coverTitle.innerText = bookCoverObj.title;
   coverTagLine1.innerText = bookCoverObj.tagline1;
   coverTagLine2.innerText = bookCoverObj.tagline2;
+
 }
 
 function randomizeBookCover() {
@@ -57,17 +63,24 @@ function randomizeBookCover() {
     descriptors[getRandomIndex(descriptors)],
     descriptors[getRandomIndex(descriptors)],
   )
-  console.log(bookCover);
   return bookCover;
+}
+
+function displayRandomOnLoad() {
+  var random = randomizeBookCover();
+  currentCover = random;
+  displayCover(random);
+
 }
 
 function displayRandomButton() {
   var buttonRandom = randomizeBookCover();
+  currentCover = buttonRandom;
   displayCover(buttonRandom);
+
 }
 
 function displayViewForm() {
-  console.log("It's a beautiful day!")
   formView.classList.remove("hidden");
   homeView.classList.add("hidden");
   saveCoverButton.classList.add("hidden");
@@ -88,12 +101,14 @@ function displaySavedCovers() {
   homeView.classList.add("hidden");
   showRandomButton.classList.add("hidden");
   saveCoverButton.classList.add("hidden");
-  homeButton.classList.remove("hidden");  
+  homeButton.classList.remove("hidden");
 }
 
 function displayUserCover() {
   event.preventDefault();
-  getUserInput();
+  var userCover = getUserInput();
+  currentCover = userCover;
+  displayCover(userCover);
   displayHomeView();
 }
 
@@ -111,9 +126,13 @@ function getUserInput() {
     userDescriptionInput1.value,
     userDescriptionInput2.value,
   )
+  return userBookCover;
   displayCover(userBookCover);
+
+
 }
 
-
-
-
+function saveCovers() {
+  savedCovers.push(currentCover)
+  console.log(savedCovers);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,7 @@ var userDescriptionInput2 = document.querySelector(".user-desc2");
 var formView = document.querySelector(".form-view");
 var homeView = document.querySelector(".home-view");
 var savedCoversView = document.querySelector(".saved-view");
+var savedCoversGrid = document.querySelector(".saved-covers-section");
 
 // Add your event listeners here 👇
 window.onLoad = displayRandomOnLoad();
@@ -130,8 +131,21 @@ function getUserInput() {
 }
 
 function saveCovers() {
-    if (!savedCovers.includes(currentCover)) {
-      savedCovers.push(currentCover)
-    }
-    console.log(savedCovers);
+  var savedCoversBox = savedCoversGrid.innerHTML
+  if (!savedCovers.includes(currentCover)) {
+    savedCovers.push(currentCover)
   }
+  formatSavedCovers();
+}
+
+function formatSavedCovers() {
+  var miniCover =
+  `
+  <div class="mini-cover">
+    <img class="mini-cover" src="${currentCover.cover}">
+    <h2 class="cover-title cover-title::first-letter"> ${currentCover.title}</h2>
+    <h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3>
+  </div>
+  `
+  savedCoversGrid.insertAdjacentHTML("afterbegin", miniCover);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -83,6 +83,7 @@ function displayRandomButton() {
 function displayViewForm() {
   formView.classList.remove("hidden");
   homeView.classList.add("hidden");
+  savedCoversView.classList.add("hidden");
   saveCoverButton.classList.add("hidden");
   showRandomButton.classList.add("hidden");
   homeButton.classList.remove("hidden");
@@ -134,8 +135,10 @@ function saveCovers() {
   var savedCoversBox = savedCoversGrid.innerHTML
   if (!savedCovers.includes(currentCover)) {
     savedCovers.push(currentCover)
+    formatSavedCovers();
+
+    console.log(savedCovers);
   }
-  formatSavedCovers();
 }
 
 function formatSavedCovers() {


### PR DESCRIPTION
## Is this a fix or a feature?
feature

## What is the change?
This completes iteration 4. When the user clicks the Save Cover button, it will save the current displaying cover. If the button is clicked when the same cover is being displayed, it will not save repeat the save. When the user clicks the View Saved Covers button, all the saved covers are displayed in a grid.

## What does it fix?
n/a

## Where should the reviewer start?
line 28 of main.js

## How should this be tested?
-click Saved Cover button
-click Show New Random Cover button
- repeat previous 2 steps(several times)
-click View Saved Covers button
-All displayed buttons from the saved covers view should still work.

#### Screenshots (if appropriate)
Screenshot of saved covers view with random saved covers and one user generated cover.
![Screen Shot 2020-08-29 at 8 48 43 PM](https://user-images.githubusercontent.com/62810592/91649382-108e0600-ea39-11ea-8116-cdd3f375555a.png)

Screenshot of a user generated cover for fun.
![Screen Shot 2020-08-29 at 8 48 08 PM](https://user-images.githubusercontent.com/62810592/91649383-23a0d600-ea39-11ea-9bed-6196f04376ad.png)



@ADavidson02,
@saraho1123
